### PR TITLE
refactor(xtask): Internally detect regex implementation

### DIFF
--- a/xtask/src/gen/mod.rs
+++ b/xtask/src/gen/mod.rs
@@ -28,7 +28,7 @@ impl RegexImpl {
     ///
     /// # Panics
     ///
-    /// Panics when zero or mutliple implementations are active
+    /// Panics when zero or multiple implementations are active
     fn detect() -> Self {
         let onig = cfg!(feature = "syntect-onig");
         let fancy = cfg!(feature = "syntect-fancy");


### PR DESCRIPTION
As opposed to explicitly pairing the fancy feature with `--only-fancy-syntaxes` for the xtask