### PR TITLE
Fix external `#[cfg(fuzzing)]` builds

### DIFF
--- a/src/fuzz.rs
+++ b/src/fuzz.rs
@@ -1,6 +1,8 @@
+use std::fs;
+
 use syntect::{dumps, parsing::SyntaxSet};
 
 pub fn fuzzer_syntaxes() -> SyntaxSet {
-    let bytes = include_bytes!("../generated/fuzzer-syntaxes.bin");
-    dumps::from_uncompressed_data(bytes).unwrap()
+    let bytes = fs::read("generated/fuzzer-syntaxes.bin").unwrap();
+    dumps::from_uncompressed_data(&bytes).unwrap()
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -164,6 +164,7 @@ pub struct ReadmeDoctests;
 pub mod acknowledgement;
 // Unstable extra code that we use for fuzzing
 #[cfg(fuzzing)]
+#[doc(hidden)]
 pub mod fuzz;
 pub mod syntax;
 pub mod theme;


### PR DESCRIPTION
Resolves #60

Relaxes finding the syntax set from a compiletime error to a runtime error and hid the module from docs (and things that consider docs)